### PR TITLE
Fixed issues #31 & #32

### DIFF
--- a/zotify/collections.py
+++ b/zotify/collections.py
@@ -194,12 +194,15 @@ class Album(Collection):
     def __init__(self, b62_id: str, api: ApiClient, config: Config = Config()):
         super().__init__(api)
         album = api.get_metadata_4_album(AlbumId.from_base62(b62_id))
+        total_discs = len(album.disc)
         for disc in album.disc:
             for track in disc.track:
                 metadata = [
                     MetadataEntry("spotid", bytes_to_base62(track.gid)),
                     MetadataEntry("album_artist", album.artist[0].name),
                     MetadataEntry("album", album.name),
+                    MetadataEntry("discnumber", disc.number),
+                    MetadataEntry("disctotal", total_discs),
                 ]
                 self.playables.append(
                     PlayableData(
@@ -233,12 +236,15 @@ class Artist(Collection):
                 album = api.get_metadata_4_album(
                     AlbumId.from_base62(bytes_to_base62(album_group.album[0].gid))
                 )
+                total_discs = len(album.disc)
                 for disc in album.disc:
                     for track in disc.track:
                         metadata = [
                             MetadataEntry("spotid", bytes_to_base62(track.gid)),
                             MetadataEntry("album_artist", album.artist[0].name),
                             MetadataEntry("album", album.name),
+                            MetadataEntry("discnumber", disc.number),
+                            MetadataEntry("disctotal", total_discs),
                         ]
                         self.playables.append(
                             PlayableData(

--- a/zotify/config.py
+++ b/zotify/config.py
@@ -62,7 +62,7 @@ CONFIG_PATHS = {
 }
 
 OUTPUT_PATHS = {
-    "album": "{album_artist}/{album}/{track_number}. {artists} - {title}",
+    "album": "{album_artist}/{album}/Disc {discnumber}/{track_number}. {artists} - {title}",
     "podcast": "{podcast}/{episode_number} - {title}",
     "playlist_track": "{playlist}/{artists} - {title}",
     "playlist_episode": "{playlist}/{episode_number} - {title}",

--- a/zotify/playable.py
+++ b/zotify/playable.py
@@ -193,6 +193,10 @@ class Track(PlayableContentFeeder.LoadedStream, Playable):
             self.track.album = self.__api().get_metadata_4_album(
                 AlbumId.from_hex(bytes_to_hex(self.album.gid))
             )
+        
+        # Get disc total if available
+        disc_total = len(self.album.disc) if hasattr(self.album, "disc") else 1
+        
         return [
             MetadataEntry("album", self.album.name),
             MetadataEntry("album_artist", self.album.artist[0].name),
@@ -201,6 +205,8 @@ class Track(PlayableContentFeeder.LoadedStream, Playable):
             MetadataEntry("artists", [a.name for a in self.artist]),
             MetadataEntry("date", f"{date.year}-{date.month}-{date.day}"),
             MetadataEntry("disc", self.disc_number),
+            MetadataEntry("discnumber", self.disc_number),
+            MetadataEntry("disctotal", disc_total),
             MetadataEntry("duration", self.duration),
             MetadataEntry("explicit", self.explicit, "[E]" if self.explicit else ""),
             MetadataEntry("isrc", self.external_id[0].id),


### PR DESCRIPTION
Two changes in this:
1. Fixed issue #32, artists who have a mix of EPs, singles, and albums now have all of their music pulled.
3. Fixed issue #31, disc number metadata is now retrieved and written to the files, as well as folder structure given multiple disc support.

### Code restructuring and issue #32 fix:
* `zotify/collections.py`:
  - Refactored the processing of artist metadata by consolidating album groups into a single list (`all_groups`) for better readability and maintainability.
  - Added exception handling to skip albums that cannot be processed, with a clear error message printed to the console.
  
### Issue #31 fix:
* `zotify/collections.py`:
  - Updated the Album and Artist classes to include disc number and total disc count in the metadata for tracks. Modified the output path format for albums to reflect the disc structure. Enhanced the Track class to retrieve and display disc information if available.