### PR TITLE
Fixed issue #35

### DIFF
--- a/zotify/playable.py
+++ b/zotify/playable.py
@@ -108,7 +108,7 @@ class Playable:
                 pass
 
             if f_spotid != spotid:
-                file_path = Path(f"{file_path} (SpotId:{spotid[-5:]})")
+                file_path = Path(f"{file_path} (SpotId-{spotid[-5:]})")
             else:
                 if not replace:
                     raise FileExistsError("File already downloaded")


### PR DESCRIPTION
Fixed issue #35.
Discovered rare bug when user have two or more songs with same name/artist in a playlist but these songs are different on Spotify (have different spotid). In that case file name are becoming like `<artist> - <song name> (SpotId:<alphanumeric_sequence>)_tmp.mp3` but in Windows system path names cannot contain colon so it raising OSError.