### PR TITLE
Padded the month and day number with a 0

### DIFF
--- a/zotify/playable.py
+++ b/zotify/playable.py
@@ -197,13 +197,16 @@ class Track(PlayableContentFeeder.LoadedStream, Playable):
         # Get disc total if available
         disc_total = len(self.album.disc) if hasattr(self.album, "disc") else 1
 
+        # Format the date here
+        formatted_date = f"{date.year}-{str(date.month).zfill(2)}-{str(date.day).zfill(2)}"
+
         return [
             MetadataEntry("album", self.album.name),
             MetadataEntry("album_artist", self.album.artist[0].name),
             MetadataEntry("album_artists", [a.name for a in self.album.artist]),
             MetadataEntry("artist", self.artist[0].name),
             MetadataEntry("artists", [a.name for a in self.artist]),
-            MetadataEntry("date", f"{date.year}-{date.month}-{date.day}"),
+            MetadataEntry("date", formatted_date),
             MetadataEntry("disc", self.disc_number),
             MetadataEntry("discnumber", self.disc_number),
             MetadataEntry("disctotal", disc_total),


### PR DESCRIPTION
If we include `{date}` in the `"output_album`, the dates are formatted in the style of '2025-1-1', this can create a disorder on same system in the form of:

- 2025.1.1
- 2025.11.1
- 2025.2.1

If we edit the Track.__default_metadata() method within playable.py by adding

```python
    # Format the date here
    formatted_date = f"{date.year}-{str(date.month).zfill(2)}-{str(date.day).zfill(2)}"  # Changed line
```

and changing the date

```python
        MetadataEntry("date", formatted_date),  # Use formatted date
```

So the total is

```python
def __default_metadata(self) -> list[MetadataEntry]:
    date = self.album.date
    if not hasattr(self.album, "genre"):
        self.track.album = self.__api.get_metadata_4_album(
            AlbumId.from_hex(bytes_to_hex(self.album.gid))
        )

    # Get disc total if available
    disc_total = len(self.album.disc) if hasattr(self.album, "disc") else 1

    # Format the date here
    formatted_date = f"{date.year}-{str(date.month).zfill(2)}-{str(date.day).zfill(2)}"  # Changed line

    return [
        MetadataEntry("album", self.album.name),
        MetadataEntry("album_artist", self.album.artist[0].name),
        MetadataEntry("album_artists", [a.name for a in self.album.artist]),
        MetadataEntry("artist", self.artist[0].name),
        MetadataEntry("artists", [a.name for a in self.artist]),
        MetadataEntry("date", formatted_date),  # Use formatted date
        MetadataEntry("disc", self.disc_number),
        MetadataEntry("discnumber", self.disc_number),
        MetadataEntry("disctotal", disc_total),
```

This should pad the date and day numbers giving us the correct order on some systems:

- 2025.01.01
- 2025.02.01
- 2025.11.01